### PR TITLE
Add pricing option for clips

### DIFF
--- a/src/app/category/[slug]/page.tsx
+++ b/src/app/category/[slug]/page.tsx
@@ -51,6 +51,9 @@ export default function CategoryPage() {
               <div className="p-3 text-white">
                 <div className="font-semibold">{clip.title}</div>
                 <div className="text-xs text-gray-400">creator: {clip.username}</div>
+                <p className="text-sm mt-1">
+                  {clip.price && clip.price > 0 ? `${clip.price} credits` : 'Free'}
+                </p>
                 <div className="flex items-center gap-4 mt-2 text-gray-300 text-xs">
                   <FaEye /> {clip.views || 0}
                   <FaDollarSign /> ${clip.tips?.toFixed(2)||'0.00'}

--- a/src/app/shop/page.tsx
+++ b/src/app/shop/page.tsx
@@ -86,7 +86,7 @@ export default function ShopPage() {
                   <div className="flex items-center justify-between mt-2">
                     <span className="flex items-center gap-1 text-blue-400 font-semibold">
                       <FaDollarSign className="text-sm" />
-                      {item.price} credits
+                      {item.price && item.price > 0 ? `${item.price} credits` : 'Free'}
                     </span>
                     <button className="bg-blue-600 text-sm text-white px-4 py-1.5 rounded hover:bg-blue-700 transition">
                       Buy

--- a/src/components/UploadClipModal.tsx
+++ b/src/components/UploadClipModal.tsx
@@ -92,7 +92,7 @@ export default function UploadClipModal({
         return;
       }
 
-      const priceInCredits = parseInt(data.price || '0', 10);
+      const priceInCredits = parseInt(data.price || '0', 10) || 0;
       const listing = {
         title: data.title.trim(),
         description: data.description.trim(),


### PR DESCRIPTION
## Summary
- save credits price when uploading a clip
- show clip price on category pages
- label shop items as free when price is zero

## Testing
- `npm run lint` *(fails: biome not found)*